### PR TITLE
[composer.json] name の修正

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "sendgrid-php-example",
+  "name": "sendgridjp/sendgrid-php-example",
   "description": "Example of using the SendGrid php library.",
   "version": "0.0.3",
   "homepage": "http://github.com/scottmotte/sendgrid-php-example",


### PR DESCRIPTION
[活用マニュアル](https://www.idcf.jp/help/cloud/guide/advanced011.html) の手順通りに実施した場合の問題を修正。

現状のcomposer.json では `composer install` 時に下記のエラーが出ます。

```
  [Composer\Json\JsonValidationException]
  "./composer.json" does not match the expected JSON schema:
   - name : Does not match the regex pattern ^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z
  0-9](([_.]?|-{0,2})[a-z0-9]+)*$
```

composerのドキュメントに従い、GitHubのユーザ名をベンダー名として追記しました。


参考）https://teratail.com/questions/306801